### PR TITLE
Remove Prisma extension recommendation from VSCode settings and README

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,6 @@
     "recommendations": [
         "esbenp.prettier-vscode",
         "dbaeumer.vscode-eslint",
-        "bradlc.vscode-tailwindcss",
-        "Prisma.prisma"
+        "bradlc.vscode-tailwindcss"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Install the recommended extensions if you are Using VSCode:
 - [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
 - [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
 - [Tailwind CSS](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss)
-- [Prisma](https://marketplace.visualstudio.com/items?itemName=Prisma.prisma)
 
 ### Contributing
 


### PR DESCRIPTION
Eliminate the recommendation for the Prisma extension in both the VSCode settings and the README file to streamline the setup instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Streamlined the recommended Visual Studio Code setup by removing a redundant extension recommendation.
- **Documentation**
	- Updated installation instructions to reflect the revised list of suggested tools for the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->