### PR TITLE
Remove dotenv configuration from drizzle and database index files

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,7 +1,4 @@
 import { defineConfig } from 'drizzle-kit';
-import { config } from 'dotenv';
-
-config({ path: '.env' });
 
 export default defineConfig({
     schema: './src/server/db/schema.ts',

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cobe": "^0.6.3",
-        "dotenv": "^16.4.7",
         "drizzle-orm": "^0.40.0",
         "framer-motion": "^12.5.0",
         "lucide-react": "^0.482.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,9 +50,6 @@ importers:
       cobe:
         specifier: ^0.6.3
         version: 0.6.3
-      dotenv:
-        specifier: ^16.4.7
-        version: 16.4.7
       drizzle-orm:
         specifier: ^0.40.0
         version: 0.40.0(@neondatabase/serverless@0.10.4)(@types/pg@8.11.6)(gel@2.0.1)
@@ -1453,10 +1450,6 @@ packages:
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
-
-  dotenv@16.4.7:
-    resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
-    engines: {node: '>=12'}
 
   draco3d@1.5.7:
     resolution: {integrity: sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==}
@@ -4145,8 +4138,6 @@ snapshots:
     dependencies:
       no-case: 3.0.4
       tslib: 2.8.1
-
-  dotenv@16.4.7: {}
 
   draco3d@1.5.7: {}
 

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -1,9 +1,6 @@
 import { drizzle } from 'drizzle-orm/neon-http';
 import { neon } from '@neondatabase/serverless';
-import { config } from 'dotenv';
 import * as schema from './schema';
-
-config({ path: '.env' });
 
 const sql = neon(process.env.DATABASE_URL!);
 export const db = drizzle(sql, { schema });


### PR DESCRIPTION
Eliminate dotenv configuration from the drizzle and database index files to streamline the setup process and reduce dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined the application's internal configuration process by removing redundant setup steps.
  - Updated project dependencies to simplify environment handling while keeping overall functionality intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->