### PR TITLE
Add relations for Company, User, Item, and SoldItem tables in schema

### DIFF
--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1,3 +1,4 @@
+import { relations } from 'drizzle-orm';
 import {
     boolean,
     date,
@@ -56,4 +57,42 @@ export const SoldItemTable = pgTable('soldItem', {
     companyId: uuid('companyId')
         .references(() => CompanyTable.id)
         .notNull(),
+});
+
+export const CompanyTableRelations = relations(
+    CompanyTable,
+    ({ one, many }) => {
+        return {
+            user: one(UserTable, {
+                fields: [CompanyTable.userId],
+                references: [UserTable.id],
+            }),
+            items: many(ItemTable),
+            soldItems: many(SoldItemTable),
+        };
+    }
+);
+
+export const UserTableRelations = relations(UserTable, ({ many }) => {
+    return {
+        companies: many(CompanyTable),
+    };
+});
+
+export const ItemTableRelations = relations(ItemTable, ({ one }) => {
+    return {
+        company: one(CompanyTable, {
+            fields: [ItemTable.companyId],
+            references: [CompanyTable.id],
+        }),
+    };
+});
+
+export const SoldItemTableRelations = relations(SoldItemTable, ({ one }) => {
+    return {
+        company: one(CompanyTable, {
+            fields: [SoldItemTable.companyId],
+            references: [CompanyTable.id],
+        }),
+    };
 });


### PR DESCRIPTION
Introduce relationships between the Company, User, Item, and SoldItem tables to enhance data integrity and enable more complex queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the underlying data structure by refining relationships between core entities. This update supports more robust querying and maintains stronger data consistency, contributing to a more reliable and responsive experience for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->