### PR TITLE
Refactor layout and update SignIn redirect

### DIFF
--- a/src/app/(with-navbar)/layout.tsx
+++ b/src/app/(with-navbar)/layout.tsx
@@ -2,8 +2,6 @@ import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import '@/app/globals.css';
 import Navbar from '@/components/Navbar';
-import { ClerkProvider } from '@clerk/nextjs';
-import { dark } from '@clerk/themes';
 
 const geistSans = Geist({
     variable: '--font-geist-sans',
@@ -26,23 +24,13 @@ export default function RootLayout({
     children: React.ReactNode;
 }>) {
     return (
-        <ClerkProvider
-            appearance={{
-                baseTheme: dark,
-                variables: {
-                    colorPrimary: '#14b8a6',
-                    colorBackground: '#000000',
-                },
-            }}
-        >
-            <html lang="en">
-                <body
-                    className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-                >
-                    <Navbar className="dark" />
-                    {children}
-                </body>
-            </html>
-        </ClerkProvider>
+        <html lang="en">
+            <body
+                className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+            >
+                <Navbar className="dark" />
+                {children}
+            </body>
+        </html>
     );
 }

--- a/src/app/(with-navbar)/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/(with-navbar)/sign-in/[[...sign-in]]/page.tsx
@@ -3,7 +3,7 @@ import { SignIn } from '@clerk/nextjs';
 export default function Page() {
     return (
         <div className="flex flex-col items-center justify-center h-screen bg-[var(--background)] dark">
-            <SignIn forceRedirectUrl={'/dashboard'} />
+            <SignIn forceRedirectUrl={'/dashboard/overview'} />
         </div>
     );
 }

--- a/src/app/(without-navbar)/layout.tsx
+++ b/src/app/(without-navbar)/layout.tsx
@@ -1,8 +1,7 @@
 'use client';
 import { Geist, Geist_Mono } from 'next/font/google';
 import '../globals.css';
-import { ClerkProvider, UserButton } from '@clerk/nextjs';
-import { dark } from '@clerk/themes';
+
 import {
     SidebarInset,
     SidebarProvider,
@@ -19,6 +18,7 @@ import {
 } from '@/components/ui/breadcrumb';
 import { Separator } from '@/components/ui/separator';
 import { usePathname } from 'next/navigation';
+import { UserButton } from '@clerk/nextjs';
 
 const geistSans = Geist({
     variable: '--font-geist-sans',
@@ -51,53 +51,43 @@ export default function RootLayout({
         '/dashboard/settings': 'Settings',
     };
     return (
-        <ClerkProvider
-            appearance={{
-                baseTheme: dark,
-                variables: {
-                    colorPrimary: '#14b8a6',
-                    colorBackground: '#000000',
-                },
-            }}
-        >
-            <html lang="en" className="dark">
-                <body
-                    className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-                >
-                    <div className="relative w-full flex items-center justify-center"></div>
-                    <SidebarProvider>
-                        <AppSidebar />
-                        <SidebarInset>
-                            <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-                                <SidebarTrigger className="-ml-1" />
-                                <Separator
-                                    orientation="vertical"
-                                    className="mr-2 data-[orientation=vertical]:h-4"
-                                />
-                                <Breadcrumb>
-                                    <BreadcrumbList>
-                                        <BreadcrumbItem className="hidden md:block">
-                                            <BreadcrumbLink href="/">
-                                                InvenTrack
-                                            </BreadcrumbLink>
-                                        </BreadcrumbItem>
-                                        <BreadcrumbSeparator className="hidden md:block" />
-                                        <BreadcrumbItem>
-                                            <BreadcrumbPage>
-                                                {map[pathname] || 'Dashboard'}
-                                            </BreadcrumbPage>
-                                        </BreadcrumbItem>
-                                    </BreadcrumbList>
-                                </Breadcrumb>
-                                <div className="ml-auto">
-                                    <UserButton />
-                                </div>
-                            </header>
-                            {children}
-                        </SidebarInset>
-                    </SidebarProvider>
-                </body>
-            </html>
-        </ClerkProvider>
+        <html lang="en" className="dark">
+            <body
+                className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+            >
+                <div className="relative w-full flex items-center justify-center"></div>
+                <SidebarProvider>
+                    <AppSidebar />
+                    <SidebarInset>
+                        <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
+                            <SidebarTrigger className="-ml-1" />
+                            <Separator
+                                orientation="vertical"
+                                className="mr-2 data-[orientation=vertical]:h-4"
+                            />
+                            <Breadcrumb>
+                                <BreadcrumbList>
+                                    <BreadcrumbItem className="hidden md:block">
+                                        <BreadcrumbLink href="/">
+                                            InvenTrack
+                                        </BreadcrumbLink>
+                                    </BreadcrumbItem>
+                                    <BreadcrumbSeparator className="hidden md:block" />
+                                    <BreadcrumbItem>
+                                        <BreadcrumbPage>
+                                            {map[pathname] || 'Dashboard'}
+                                        </BreadcrumbPage>
+                                    </BreadcrumbItem>
+                                </BreadcrumbList>
+                            </Breadcrumb>
+                            <div className="ml-auto">
+                                <UserButton />
+                            </div>
+                        </header>
+                        {children}
+                    </SidebarInset>
+                </SidebarProvider>
+            </body>
+        </html>
     );
 }


### PR DESCRIPTION
Remove the ClerkProvider from layout components to simplify the structure and update the SignIn component to redirect users to the dashboard overview instead of the main dashboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined page layouts in both navbar and non-navbar views by removing a redundant authentication wrapper, leading to a simpler and more maintainable structure.
  
- **New Features**
  - Updated the sign-in flow so that users are now redirected to a dedicated dashboard overview page after logging in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->